### PR TITLE
Buffs/Debuffs and Message Speed

### DIFF
--- a/src/main/java/Attacks/Attack.java
+++ b/src/main/java/Attacks/Attack.java
@@ -101,8 +101,8 @@ public abstract class Attack {
                         System.out.println(target.getName() + " took " + damage + " damage!");
                     else
                         System.out.println(target.getName() + " recovered " + Math.abs(damage) + " HP");
+                    sleep();
                 }
-                sleep();
                 Map<String, Integer> oldUserBuffs = new HashMap<String,Integer>(user.getBuffMap());
                 Map<String, Integer> oldTargetBuffs = new HashMap<String,Integer>(target.getBuffMap());
                 if(addEffects(user, target)){ //if effects added & add effects

--- a/src/main/java/Attacks/Attack.java
+++ b/src/main/java/Attacks/Attack.java
@@ -53,8 +53,10 @@ public abstract class Attack {
         }
         if(target.isGuarding()) { damage /= 2;} //halve damage if guarding
 
-        damage += (int)(damage * user.getBuffRate("atk"));
-        damage -= (int)(damage * target.getBuffRate("def"));
+        int damageBefore = damage;
+        damage += (int)(damageBefore * user.getBuffRate("atk"));
+        damage -= (int)(damageBefore * target.getBuffRate("def"));
+        if((damageBefore ^ damage) < 0) damage = 0; //if signs are different
 
         //If you are targeting yourself, negative damage can heal
         //So we don't set a floor, but if you are attempting to hit an enemy,

--- a/src/main/java/Attacks/Attack.java
+++ b/src/main/java/Attacks/Attack.java
@@ -7,6 +7,7 @@ import java.util.Map;
 public abstract class Attack {
 
     /** Attack Constants **/
+    private static int sleepTime = 500; //amount to wait between messages
     public static final int PHYSICAL = 0; //subject to hit/evasion rates
     public static final int GUARANTEED = 1; //guaranteed to hit, ignore hit/evasion rates
     public static final int EFFECTS = 2; //status effects/buffs, doesn't print attack message, ignore player hit/evasion rates
@@ -49,7 +50,7 @@ public abstract class Attack {
         damage = applyVariance(damage);
         if (crit(user)) { //if crit
             damage = applyCrit(damage); //multiply attack
-            System.out.println(getCritMessage(user,target));
+            System.out.println(getCritMessage(user,target)); sleep();
         }
         if(target.isGuarding()) { damage /= 2;} //halve damage if guarding
 
@@ -70,10 +71,10 @@ public abstract class Attack {
     /* Hit Processing: Processes Misses and Evasions */
     public boolean processHit(Battler user, Battler target){
         if (missed(user)) { //if missed
-            System.out.println(getMissMessage(user, target));
+            System.out.println(getMissMessage(user, target)); sleep();
             return false;
         } else if (evaded(target)) { //if attack evaded
-            System.out.println(getEvaMessage(user, target));
+            System.out.println(getEvaMessage(user, target)); sleep();
             return false;
         }
         return true;
@@ -83,12 +84,12 @@ public abstract class Attack {
     public void processAttack(Battler user, Battler target){
         int damage = 0;
         if(mpCost > user.getMP()){
-            System.out.printf("Not enough MP! %s failed!\n",skillName);
+            System.out.printf("Not enough MP! %s failed!\n",skillName); sleep();
             return;
         } else {
             user.subtractMP(mpCost);
         }
-        System.out.println(getMessage(user,target));
+        System.out.println(getMessage(user,target)); sleep();
         for(int i = 0; i < numOfHits; i++){
             if(processHit(user,target)){
                 damage = processDamage(user,target);
@@ -99,6 +100,7 @@ public abstract class Attack {
                     else
                         System.out.println(target.getName() + " recovered " + Math.abs(damage) + " HP");
                 }
+                sleep();
                 Map<String, Integer> oldUserBuffs = new HashMap<String,Integer>(user.getBuffMap());
                 Map<String, Integer> oldTargetBuffs = new HashMap<String,Integer>(target.getBuffMap());
                 if(addEffects(user, target)){ //if effects added & add effects
@@ -108,14 +110,16 @@ public abstract class Attack {
                 }
             }
         }
-        System.out.printf("%s has %d health remaining\n\n",target.getName(),target.getHP());
+        //System.out.printf("%s has %d health remaining\n\n",target.getName(),target.getHP());
+        sleep();
+        System.out.println();
     }
     /* Process a specific buff for the select battler */
     public boolean processBuff(Battler battler, Map<String, Integer> oldBuffs,
                                String buffType, String buffName){
         int difference = battler.getBuff(buffType) - oldBuffs.get(buffType); //buff now - buff before
         if(difference != 0){ //if buff/debuff is actually applied
-            System.out.println(getBuffMessage(battler.getName(), buffName, difference));
+            System.out.println(getBuffMessage(battler.getName(), buffName, difference)); sleep();
             return true;
         }
         return false;
@@ -167,6 +171,22 @@ public abstract class Attack {
         if(attackType == GUARANTEED || attackType == EFFECTS) return false;
         int rate = target.getEvaRate();
         return Rates.percentRateApplied(rate);
+    }
+    /* Wait Between Messages */
+    public static void sleep(){
+        try {Thread.sleep(sleepTime);
+        } catch (Exception e) {System.out.println(e);}
+    }
+    public static void changeSleepTime2(int sleepTime2){
+        sleepTime = sleepTime2;
+    }
+    public static void changeSleepTime(int sleepTime2){ //options: 1000,500,250
+        switch(sleepTime2){
+            case 1: changeSleepTime2(1000); break;
+            case 2: changeSleepTime2(500); break;
+            case 3: changeSleepTime2(250); break;
+            case 4: changeSleepTime2(0); break;
+        }
     }
     /* Get Messages for cases of a Critical Hit, Miss, or Evaded Hit */
     public String getCritMessage(Battler user, Battler target){

--- a/src/main/java/Attacks/Attack.java
+++ b/src/main/java/Attacks/Attack.java
@@ -7,10 +7,12 @@ import java.util.Map;
 public abstract class Attack {
 
     /** Attack Constants **/
-    private static int sleepTime = 500; //amount to wait between messages
     public static final int PHYSICAL = 0; //subject to hit/evasion rates
     public static final int GUARANTEED = 1; //guaranteed to hit, ignore hit/evasion rates
     public static final int EFFECTS = 2; //status effects/buffs, doesn't print attack message, ignore player hit/evasion rates
+
+    /** Attack Settings **/
+    private static int sleepTime = 500; //amount to wait between messages
 
     /** Attack Parameters **/
     private int mpCost; //cost of skill to use

--- a/src/main/java/Attacks/Attack.java
+++ b/src/main/java/Attacks/Attack.java
@@ -182,13 +182,8 @@ public abstract class Attack {
     public static void changeSleepTime2(int sleepTime2){
         sleepTime = sleepTime2;
     }
-    public static void changeSleepTime(int sleepTime2){ //options: 1000,500,250
-        switch(sleepTime2){
-            case 1: changeSleepTime2(1000); break;
-            case 2: changeSleepTime2(500); break;
-            case 3: changeSleepTime2(250); break;
-            case 4: changeSleepTime2(0); break;
-        }
+    public static void changeSleepTime(int sleepTime2){ //options: 1000,750,500,250,0
+        changeSleepTime2(1000 - 250 * (sleepTime2-1));
     }
     /* Get Messages for cases of a Critical Hit, Miss, or Evaded Hit */
     public String getCritMessage(Battler user, Battler target){

--- a/src/main/java/Attacks/Bash.java
+++ b/src/main/java/Attacks/Bash.java
@@ -14,9 +14,7 @@ public class Bash extends Attack {
     public int calcDamage(Battler user, Battler target){
         return Math.max(0, user.getAtk() * 4 - target.getDef() * 2);
     }
-    public void addEffects(Battler user, Battler target){
-        // does nothing
-    }
+    public boolean addEffects(Battler user, Battler target) {return false;}
     public String getMessage(Battler user, Battler target){
         return user.getName() + " bashes into " + target.getName() + "!";
     }

--- a/src/main/java/Attacks/BasicAttack.java
+++ b/src/main/java/Attacks/BasicAttack.java
@@ -1,10 +1,10 @@
 package Attacks;
 import Battlers.*;
 
-public class DefaultAttack extends Attack {
+public class BasicAttack extends Attack {
 
     /** DefaultAttack values **/
-    public DefaultAttack(){
+    public BasicAttack(){
         super();
         setSkillName("Attack");
     }
@@ -13,8 +13,8 @@ public class DefaultAttack extends Attack {
     public int calcDamage(Battler user, Battler target){
         return Math.max(0, user.getAtk() * 2 - target.getDef());
     }
-    public void addEffects(Battler user, Battler target){
-        // does nothing
+    public boolean addEffects(Battler user, Battler target){
+        return false;
     }
     public String getMessage(Battler user, Battler target){
         return user.getName() + " attacks!";

--- a/src/main/java/Attacks/DebilitatingSlash.java
+++ b/src/main/java/Attacks/DebilitatingSlash.java
@@ -1,0 +1,26 @@
+package Attacks;
+
+import Battlers.Battler;
+
+public class DebilitatingSlash extends Attack {
+
+    /** DebilitatingSlash values **/
+    public DebilitatingSlash(){
+        super();
+        setMpCost(50);
+        setSkillName("Debilitating Slash");
+        setCritRate(10);
+        setNumOfHits(2);
+    }
+
+    /** Attack methods **/
+    public int calcDamage(Battler user, Battler target){return Math.max(0, user.getAtk() * 4 - target.getDef());}
+    public boolean addEffects(Battler user, Battler target){
+        target.debuff("atk", 1);
+        return true;
+    }
+    public String getMessage(Battler user, Battler target){
+        return user.getName() + " uses Debilitating Slash!";
+    }
+
+}

--- a/src/main/java/Attacks/DefenseDown.java
+++ b/src/main/java/Attacks/DefenseDown.java
@@ -1,0 +1,23 @@
+package Attacks;
+import Battlers.*;
+
+public class DefenseDown extends Attack {
+
+    /** DefenseDown values **/
+    public DefenseDown(){
+        super();
+        setSkillName("Defense Down");
+        setAttackType(EFFECTS);
+        setCritAbility(false);
+    }
+
+    /** Attack methods **/
+    public int calcDamage(Battler user, Battler target){return 0;}
+    public boolean addEffects(Battler user, Battler target){
+        target.debuff("def", 1);
+        return true;
+    }
+    public String getMessage(Battler user, Battler target){return user.getName() + " casts Defense Down!";
+    }
+
+}

--- a/src/main/java/Attacks/DefenseDown.java
+++ b/src/main/java/Attacks/DefenseDown.java
@@ -6,6 +6,7 @@ public class DefenseDown extends Attack {
     /** DefenseDown values **/
     public DefenseDown(){
         super();
+        setMpCost(10);
         setSkillName("Defense Down");
         setAttackType(EFFECTS);
         setCritAbility(false);

--- a/src/main/java/Attacks/DesperateHit.java
+++ b/src/main/java/Attacks/DesperateHit.java
@@ -17,8 +17,8 @@ public class DesperateHit extends Attack {
     public int calcDamage(Battler user, Battler target){
         return Math.max(0, user.getAtk() * 2 - target.getDef());
     }
-    public void addEffects(Battler user, Battler target){
-        // does nothing
+    public boolean addEffects(Battler user, Battler target){
+        return false;
     }
     public String getMessage(Battler user, Battler target){
         return user.getName() + " hits " + target.getName() + " with a desperate attack!";

--- a/src/main/java/Attacks/DualSlash.java
+++ b/src/main/java/Attacks/DualSlash.java
@@ -16,8 +16,8 @@ public class DualSlash extends Attack {
     public int calcDamage(Battler user, Battler target){
         return Math.max(0, user.getAtk() * 2 - target.getDef());
     }
-    public void addEffects(Battler user, Battler target){
-        // does nothing
+    public boolean addEffects(Battler user, Battler target){
+        return false;
     }
     public String getMessage(Battler user, Battler target){
         return user.getName() + " attacks twice!";

--- a/src/main/java/Attacks/Heal.java
+++ b/src/main/java/Attacks/Heal.java
@@ -15,8 +15,8 @@ public class Heal extends Attack {
     public int calcDamage(Battler user, Battler target){
         return Math.min(0, target.getMaxHP() / -3);
     }
-    public void addEffects(Battler user, Battler target){
-        // does nothing
+    public boolean addEffects(Battler user, Battler target){
+        return false;
     }
     public String getMessage(Battler user, Battler target){
         return target.getName() + " casts Heal!";

--- a/src/main/java/Attacks/InstantKill.java
+++ b/src/main/java/Attacks/InstantKill.java
@@ -17,8 +17,8 @@ public class InstantKill extends Attack {
     public int calcDamage(Battler user, Battler target){
         return Math.max(0, target.getHP());
     }
-    public void addEffects(Battler user, Battler target){
-        // does nothing
+    public boolean addEffects(Battler user, Battler target){
+        return false;
     }
     public String getMessage(Battler user, Battler target){
         return user.getName() + " kills " + target.getName() + " immediately!";

--- a/src/main/java/Attacks/Peer.java
+++ b/src/main/java/Attacks/Peer.java
@@ -1,0 +1,29 @@
+package Attacks;
+
+import Battlers.Battler;
+
+public class Peer extends Attack {
+
+    /** Peer values **/
+    public Peer(){
+        super();
+        setMpCost(15);
+        setSkillName("Peer");
+        setCritAbility(false);
+        setAttackType(EFFECTS);
+    }
+
+    /** Attack methods **/
+    public int calcDamage(Battler user, Battler target){
+        return 0;
+    }
+    public boolean addEffects(Battler user, Battler target){
+        System.out.println(target.getName() + "'s HP: " + target.getHP() + "/" + target.getMaxHP()); sleep();
+        System.out.println(target.getName() + "'s MP: " + target.getMP() + "/" + target.getMaxMP()); sleep();
+        return false; //just dont want it to print "nothing happened!"
+    }
+    public String getMessage(Battler user, Battler target){
+        return user.getName() + " peers through the enemy's defenses!";
+    }
+
+}

--- a/src/main/java/Attacks/Pierce.java
+++ b/src/main/java/Attacks/Pierce.java
@@ -15,8 +15,8 @@ public class Pierce extends Attack {
     public int calcDamage(Battler user, Battler target){
         return Math.max(0, user.getAtk());
     }
-    public void addEffects(Battler user, Battler target){
-        // does nothing
+    public boolean addEffects(Battler user, Battler target){
+        return false;
     }
     public String getMessage(Battler user, Battler target){
         return user.getName() + " pierces through " + target.getName() + "'s defense!";

--- a/src/main/java/Attacks/VariantStrike.java
+++ b/src/main/java/Attacks/VariantStrike.java
@@ -16,8 +16,8 @@ public class VariantStrike extends Attack {
     public int calcDamage(Battler user, Battler target){
         return Math.max(0, user.getAtk() * 2 - target.getDef());
     }
-    public void addEffects(Battler user, Battler target){
-        // does nothing
+    public boolean addEffects(Battler user, Battler target){
+        return false;
     }
     public String getMessage(Battler user, Battler target){
         return user.getName() + " uses Variant Strike!";

--- a/src/main/java/Battlers/Battler.java
+++ b/src/main/java/Battlers/Battler.java
@@ -67,7 +67,7 @@ public class Battler {
                 System.out.println(name + " guards\n");
                 setGuard(true);
                 break;
-            case "Cower":
+            case "Cower": //nothing happens here
                 System.out.println(name + " cowers in fear!\n");
                 break;
             default:
@@ -90,7 +90,7 @@ public class Battler {
         buff(buffType, amount*-1);
     }
 
-    public double getBuffRate(String buffType){
+    public double getBuffRate(String buffType){ // buff amount * buffrate in percent form
         return getBuff(buffType) * ((double)buffRate / 100);
     }
 

--- a/src/main/java/Battlers/Battler.java
+++ b/src/main/java/Battlers/Battler.java
@@ -164,12 +164,18 @@ public class Battler {
 
     public void setCurrentAttack(Attack currentAttack) {this.currentAttack = currentAttack;}
 
+    public void defaultCurrentAttack() {currentAttack = defaultAttack;}
+
+    public boolean usedDefaultAttack() {
+        if(currentAttack == defaultAttack) return true;
+        return false;
+    }
+
     public Set<Attack> getSpecialAttacks() {return specialAttacks;}
 
     public void addSpecialAttack(Attack specialAttack) {this.specialAttacks.add(specialAttack);}
 
     public void endTurn() {
-        setCurrentAttack(defaultAttack);
     	setGuard(false);
     }
 

--- a/src/main/java/Battlers/Battler.java
+++ b/src/main/java/Battlers/Battler.java
@@ -64,14 +64,14 @@ public class Battler {
                 currentAttack.processAttack(this, target);
                 break;
             case "Guard":
-                System.out.println(name + " guards\n");
+                System.out.println(name + " guards\n"); Attack.sleep();
                 setGuard(true);
                 break;
             case "Cower": //nothing happens here
-                System.out.println(name + " cowers in fear!\n");
+                System.out.println(name + " cowers in fear!\n"); Attack.sleep();
                 break;
             default:
-                System.out.println("Invalid action selected");
+                System.out.println("Invalid action selected"); Attack.sleep();
                 break;
         }
 

--- a/src/main/java/Battlers/Battler.java
+++ b/src/main/java/Battlers/Battler.java
@@ -15,8 +15,11 @@ public class Battler {
     private int EvaRate; //evasion rate (0-100)
     private String name;
     private boolean guard;
+    private Attack defaultAttack;
     private Attack currentAttack;
     private Set<Attack> specialAttacks;
+    private final int buffCap = 3, buffRate = 30; //buffcap is cap of buffs
+    private Map<String, Integer> buffs; //Map of buffs, string: parameter name, integer: amount * rate
 
     public Battler(){
         this("",0,0,0,0,0,0,0,100,0);
@@ -35,8 +38,10 @@ public class Battler {
         this.HitRate = HitRate;
         this.EvaRate = EvaRate;
         guard = false;
-        currentAttack = new DefaultAttack();
+        defaultAttack = new BasicAttack();
+        currentAttack = defaultAttack;
         specialAttacks = new HashSet<Attack>();
+        initBuffMap();
     }
 
     public Battler(String name, int HP, int MaxHP, int MP, int MaxMP, int Atk, int Def){
@@ -47,18 +52,46 @@ public class Battler {
         this(name, HP, HP, MP, MP, Atk, Def);
     }
 
+    public void initBuffMap(){
+        buffs = new HashMap<String, Integer>();
+        buffs.put("atk", 0);
+        buffs.put("def", 0);
+    }
+
     public void useAction(Battler target,String action){
-        if(action.equals("Attack")){
-            currentAttack.processAttack(this,target);
-        } else if(action.equals("Guard")){
-        	System.out.println(name + " guards\n");
-            setGuard(true);
-        } else if(action.equals("Cower")){
-            System.out.println(name + " cowers in fear!\n");
-        } else{
-            System.out.println("Invalid action selected");
+        switch (action) {
+            case "Attack":
+                currentAttack.processAttack(this, target);
+                break;
+            case "Guard":
+                System.out.println(name + " guards\n");
+                setGuard(true);
+                break;
+            case "Cower":
+                System.out.println(name + " cowers in fear!\n");
+                break;
+            default:
+                System.out.println("Invalid action selected");
+                break;
         }
 
+    }
+
+    public void buff(String buffType, int amount){
+        switch(buffType){
+            case "atk": case "def":
+                buffs.put(buffType, (Math.max(buffCap*-1, Math.min(buffCap, buffs.get(buffType)+amount))));
+                break; //min: -buffCap, max: buffCap, add amount to value in map
+            default:
+                System.out.println("INVALID BUFF TYPE!"); break;
+        }
+    }
+    public void debuff(String buffType, int amount){
+        buff(buffType, amount*-1);
+    }
+
+    public double getBuffRate(String buffType){
+        return getBuff(buffType) * ((double)buffRate / 100);
     }
 
 
@@ -121,34 +154,32 @@ public class Battler {
 
     public boolean isGuarding() {return guard;}
 
-    public void setGuard(boolean guard) {
-    	this.guard = guard;
-    	//Def = Def * 2; 
-    	}
+    public void setGuard(boolean guard) {this.guard = guard;}
 
-    public Attack getCurrentAttack() {
-        return currentAttack;
-    }
+    public Attack getDefaultAttack() {return defaultAttack;}
 
-    public void setCurrentAttack(Attack currentAttack) {
-        this.currentAttack = currentAttack;
-    }
+    public void setDefaultAttack(Attack defaultAttack) {this.defaultAttack = defaultAttack;}
 
-    public Set<Attack> getSpecialAttacks() {
-        return specialAttacks;
-    }
+    public Attack getCurrentAttack() {return currentAttack;}
 
-    public void addSpecialAttack(Attack specialAttack) {
-        this.specialAttacks.add(specialAttack);
-    }
+    public void setCurrentAttack(Attack currentAttack) {this.currentAttack = currentAttack;}
+
+    public Set<Attack> getSpecialAttacks() {return specialAttacks;}
+
+    public void addSpecialAttack(Attack specialAttack) {this.specialAttacks.add(specialAttack);}
+
     public void endTurn() {
-        setCurrentAttack(new DefaultAttack());
-    	//Def = Def / 2;
-    	this.guard = false;
-    	
+        setCurrentAttack(defaultAttack);
+    	setGuard(false);
     }
 
-    public Attack[] getSpecialAttacksArray(){
-        return specialAttacks.toArray(new Attack[1]);
+    public Attack[] getSpecialAttacksArray(){return specialAttacks.toArray(new Attack[0]);}
+
+    public int getBuff(String buffType){
+        return buffs.get(buffType);
+    }
+
+    public Map<String, Integer> getBuffMap(){
+        return buffs;
     }
 }

--- a/src/main/java/Battlers/Player.java
+++ b/src/main/java/Battlers/Player.java
@@ -13,6 +13,7 @@ public class Player extends Battler{
         addSpecialAttack(new DesperateHit());
         addSpecialAttack(new Heal());
         addSpecialAttack(new InstantKill());
+        addSpecialAttack(new DefenseDown());
     }
 
     public Player(){
@@ -97,7 +98,7 @@ public class Player extends Battler{
             userInt = sc.nextInt();
             if(userInt == -1){
                 //System.out.println(getName() + " out of options selects Attack!");
-                return new DefaultAttack();
+                return getDefaultAttack();
             }
             else if(userInt < 1 || userInt > specials.length){ System.out.println("Invalid Skill!");}
             else if(!specials[userInt-1].isUsableMp(this)){ //if not usable

--- a/src/main/java/Battlers/Player.java
+++ b/src/main/java/Battlers/Player.java
@@ -83,10 +83,10 @@ public class Player extends Battler{
             if(!specials[i].isUsableMp(this)) usable = "[X]";
             else usable = "   ";
             System.out.format("%-21s",(i+1) + ": " + specials[i].getSkillName());
-            System.out.format("%-4s","[" + specials[i].getMpCost() + "]"); //set this to %-6s if skills use triple digit MP
+            System.out.format("%-4s","[" + specials[i].getMpCost() + "]"); //set this to %-5s if skills use triple digit MP
             System.out.print(usable + " ");
             if(specials[i].isUsableMp(this)) anyUse = true;
-            if(i % 3 == 2 || i == len-1) System.out.println();
+            if(i % 3 == 2 || i == len-1) System.out.println(); //3 skills per row
         }
         if(!anyUse) System.out.println("-1: Cower");
     }

--- a/src/main/java/Battlers/Player.java
+++ b/src/main/java/Battlers/Player.java
@@ -15,6 +15,7 @@ public class Player extends Battler{
         addSpecialAttack(new InstantKill());
         addSpecialAttack(new DefenseDown());
         addSpecialAttack(new DebilitatingSlash());
+        addSpecialAttack(new Peer());
     }
 
     public Player(){
@@ -82,7 +83,8 @@ public class Player extends Battler{
             //System.out.print((i+1) + ": " + specials[i].getSkillName());
             if(!specials[i].isUsableMp(this)) usable = "[X]";
             else usable = "   ";
-            System.out.format("%-21s",(i+1) + ": " + specials[i].getSkillName());
+            System.out.format("%-3s", (i+1) + ":");
+            System.out.format("%-18s",specials[i].getSkillName());
             System.out.format("%-4s","[" + specials[i].getMpCost() + "]"); //set this to %-5s if skills use triple digit MP
             System.out.print(usable + " ");
             if(specials[i].isUsableMp(this)) anyUse = true;

--- a/src/main/java/Battlers/Player.java
+++ b/src/main/java/Battlers/Player.java
@@ -73,7 +73,7 @@ public class Player extends Battler{
 
     public void attackMenuPrint(Attack[] specials){
         Scanner sc = new Scanner(System.in);
-        System.out.println("Total MP: " + getMP());
+        System.out.println("MP: " + getMP() + "/" + getMaxMP());
         int i, userInt = 0, len;
         String usable;
         len = specials.length;

--- a/src/main/java/Battlers/Player.java
+++ b/src/main/java/Battlers/Player.java
@@ -14,6 +14,7 @@ public class Player extends Battler{
         addSpecialAttack(new Heal());
         addSpecialAttack(new InstantKill());
         addSpecialAttack(new DefenseDown());
+        addSpecialAttack(new DebilitatingSlash());
     }
 
     public Player(){
@@ -81,8 +82,8 @@ public class Player extends Battler{
             //System.out.print((i+1) + ": " + specials[i].getSkillName());
             if(!specials[i].isUsableMp(this)) usable = "[X]";
             else usable = "   ";
-            System.out.format("%-20s",(i+1) + ": " + specials[i].getSkillName());
-            System.out.format("%-5s"," [" + specials[i].getMpCost() + "]"); //set this to %-6s if skills use triple digit MP
+            System.out.format("%-21s",(i+1) + ": " + specials[i].getSkillName());
+            System.out.format("%-4s","[" + specials[i].getMpCost() + "]"); //set this to %-6s if skills use triple digit MP
             System.out.print(usable + " ");
             if(specials[i].isUsableMp(this)) anyUse = true;
             if(i % 3 == 2 || i == len-1) System.out.println();

--- a/src/main/java/main.java
+++ b/src/main/java/main.java
@@ -130,8 +130,8 @@ public class main {
 
 	public static void changeTextSpeed(){
 		userInt = 0;
-		while(userInt > 4 || userInt < 1) {
-			System.out.println("Enter Text Speed (1-4):");
+		while(userInt > 5 || userInt < 1) {
+			System.out.println("Enter Text Speed (1-5):");
 			userInt = stdin.nextInt();
 		}
 		Attack.changeSleepTime(userInt);

--- a/src/main/java/main.java
+++ b/src/main/java/main.java
@@ -46,6 +46,7 @@ public class main {
 				userInt = stdin.nextInt();
 				switch(userInt){
 					case 1:
+						player.defaultCurrentAttack();
 						player.useAction(enemy, "Attack");
 						if (enemy.getHP() > 0) {
 							enemy.useAction(player, "Attack");
@@ -53,7 +54,7 @@ public class main {
 						break;
 					case 2:
 						player.setCurrentAttack(player.attackMenu(player.getSpecialAttacksArray()));
-						if(player.getCurrentAttack().getSkillName().equals("Attack")){
+						if(player.usedDefaultAttack()){
 							player.useAction(enemy, "Cower");
 						}
 						else{
@@ -62,6 +63,7 @@ public class main {
 						if (enemy.getHP() > 0) {
 							enemy.useAction(player, "Attack");
 						}
+						player.defaultCurrentAttack();
 						break;
 					case 3:
 						player.useAction(enemy, "Guard");

--- a/src/main/java/main.java
+++ b/src/main/java/main.java
@@ -43,6 +43,8 @@ public class main {
 		while(!fin){
 			while (player.getHP() > 0 && enemy.getHP() > 0) {
 				//System.out.println("Enter 1 for attack. Enter 2 for Special. Enter 3 for Guard. Enter -1 to quit.");
+				System.out.print("HP: " + player.getHP() + "/" + player.getMaxHP());
+				System.out.println(" MP: " + player.getMP() + "/" + player.getMaxMP());
 				System.out.println("1: Attack 2: Special 3: Guard -1: Quit 0: Options ");
 				userInt = stdin.nextInt();
 				switch(userInt){

--- a/src/main/java/main.java
+++ b/src/main/java/main.java
@@ -39,10 +39,11 @@ public class main {
 	}
 
 	static private void battleLoop(){
+		boolean options = false;
 		while(!fin){
 			while (player.getHP() > 0 && enemy.getHP() > 0) {
 				//System.out.println("Enter 1 for attack. Enter 2 for Special. Enter 3 for Guard. Enter -1 to quit.");
-				System.out.println("1: Attack 2: Special 3: Guard -1: Quit");
+				System.out.println("1: Attack 2: Special 3: Guard -1: Quit 0: Options ");
 				userInt = stdin.nextInt();
 				switch(userInt){
 					case 1:
@@ -71,19 +72,26 @@ public class main {
 							enemy.useAction(player, "Attack");
 						}
 						break;
+					case 0:
+						options = true;
+						changeTextSpeed();
+						break;
 					case -1:
 						System.out.print(player.getName() + " fled the scene!\nThe battle is over!");
 						System.exit(1);
 						break;
 					default:
-						System.out.println(player.getName() + " fumbled and pressed an invalid number!");
+						System.out.println(player.getName() + " fumbled and pressed an invalid number!"); Attack.sleep();
 						if (enemy.getHP() > 0) {
 							enemy.useAction(player, "Attack");
 						}
 						break;
 				}
-				player.endTurn();
-				enemy.endTurn();
+				if(!options) {
+					player.endTurn();
+					enemy.endTurn();
+				}
+				else options = false;
 			}
 			fin = checkIfFinished();
 		}
@@ -99,6 +107,7 @@ public class main {
 		else{
 			System.out.println("Something ended... I guess???");
 		}
+		Attack.sleep();
 
 		while(true) {
 			System.out.println("Do you want to play again? Enter \"yes\" or \"no\".");
@@ -117,5 +126,14 @@ public class main {
 			}
 		}
 		return fin;
+	}
+
+	public static void changeTextSpeed(){
+		userInt = 0;
+		while(userInt > 4 || userInt < 1) {
+			System.out.println("Enter Text Speed (1-4):");
+			userInt = stdin.nextInt();
+		}
+		Attack.changeSleepTime(userInt);
 	}
 }


### PR DESCRIPTION
This is the implementation of Buffs and Debuffs within the battler. The attack class does not hold any variables dictating buff amount, since only battlers can be buffed or debuffed. These buffs are stored in a map within the battler called "buffs". This map is a key value pair of String and Integer with the string being the variable name of the stat, and the integer how far it has been buffed or debuffed. Say the string is "atk", this means this refers to the buff/debuff attack. Now how do we know how far this has been buffed or debuffed? The integer, obviously. Negative numbers refer to debuffs while positive numbers refer to buffs. So if the value of the "atk" key is -2, attack has been debuffed twice. But then how does this affect the damage values? This is determined by the rate stored within "buffRate". This is the percent value added or subtracted to the damage at every value of buff/debuff. So in this instance if buffRate was 30 (which I've set it as as default), and the value of the "atk" key was -2, this would mean its effect on damage would be damage + (-2 * 30%) or damage - 60%, so their damage now outputs 60% less than before. This is how buffs and debuffs work currently. There are no buff or debuff turn limits, but there is a cap. Buff and debuff caps are determined by the value buffCap, which is currently 3. This means values within the map cannot exceed 3 or -3. This is how buffs work.

Additionally, I added a new function to attack called sleep(). This will be called after every battle message. The speed of this is stored in a variable called "sleepTime". There is a method also within attack that will change sleepTime. Because this uses milliseconds, I added a function that changes the speed based on numbers. 1 being slowest, 2 slow, 3 normal, 4 fast, and 5 instant. By default this is 3 (or 500ms). This function is changeSleepTime(). This can be changed within the Battle UI which I added a new option called "0: Options". Because of this, I needed a boolean that kept track if the options menu was entered, and to prevent endTurn() if so.

Changes to Battler:
* added defaultAttack variable. This holds the attack subclass for the attack selected when choosing "Attack". This is not a special attack. currentAttack is set to this when "Attack" is chosen and after the special attack is finished instead of in endTurn().
* Changed useAction()'s if statements into a switch case, since it was only comparing various Strings.
* Added Map called buffs. I explained this earlier but this keeps track of buffs.
* Added functions buff(), debuff(), and getBuffRate(). buff() will add the amount of buff/debuff to a certain value given, but will prevent this if the buffCap is reached. debuff() is just buff but the amount is negative. getBuffRate() returns the percentage to be applied to damage.
* added various getters and setters

Changes to Player:
* Special Menu now formats the name to fit before the mana cost without a space after the name.
* Special Menu now formats the input number before the name to exclude the space if specialAttacks are in the double digits.
* Added the two new skills for testing purposes

Changes to Attack:
* addEffects() now returns a boolean. It returns true if effects are applied, and false if effects are not applied.
* processBuff(), processBuffs(), and processAllBuffs() have been added. These print out the messages required for after buffs or debuffs are applied. The difference is stated in the comments.
* added new attackType called "EFFECTS". This will ignore evasion rates and player hit rates. Only skill hit rates matter. This will also not print the "Player did X damage!" message. This is because effects do not always need to do damage.
* addEffects() is now processed AFTER damage has been taken away from the target. This is to prevent debuffs from having an active effect if they were applied by a skill that also did damage.
* processDamage() now applies buffs and debuffs to damage calculation.
* The message "Nothing happened!" will appear if effects were applied, the attack type is "EFFECTS", no buffs or debuffs were applied to anyone, AND the damage is 0. I do not want this message to appear often. Only to let the user know their effect wasn't applied or such.
Also, I feel my implementation wasn't that great for checking if buffs were applied. I stored two maps of the buffs for the user and target before addEffects() was called, and then processBuffs() compares that to the current one within the battler objects. If there is a better way of implementing that, I'd appreciate it.
* new variable called sleepTime. This is how long the program will wait when sleep() is called. sleep() should be called after most battle messages.
* new functions sleep(), changeSleepTime(), and changeSleepTime2(). sleep() will sleep for sleepTime amount, changeSleepTime2() takes milliseconds as a parameter and changes sleepTime to that. changeSleepTime() changes the sleepTime to preset milliseconds with options being 1-4.
* The message "Battler has HP remaining HP" is commented out. I mainly envisioned this as a testing print statement. I think we want the finished thing to exclude it. If battles take too long, we could lower the HP totals or just rebalance the whole thing. To compensate for this, I added a "Peer" skill.

Various changes to Attack subclasses:
* DefaultAttack is now BasicAttack to avoid confusion with defaultAttack variable
* addEffects() returns false in classes that don't apply effects
* Two new skills: Defense Down (Lowers defense by 1) and Debilitating Slash (Attacks twice and lowers attack by 1 (for each slash))
* New skill called "Peer". When this is used, it will print the enemy's HP/MaxHp and MP/MaxMP. This was to compensate for removing the "HP remaining" message. I think it's better this way.

Changes to main():
* Options Menu has been added where you can change the text speed
* changeTextSpeed() has been added which will ask the user for a number and change the text speed of battle messages.
* endTurn() is now only called if boolean options is false. This is set to true if 0: Options is selected.
* Prints HP/MaxHP and MP/MaxMP for the player before the menu appears